### PR TITLE
Fix PING/PONG

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -188,7 +188,7 @@ func (c *Client) receive() {
 
 			if evt, err := event.ParseEvent(line); err == nil {
 				if evt.Command == event.PING {
-					source := strings.Join(evt.Args[1:], " ")
+					source := strings.Join(evt.Args, " ")
 					c.Conn.Pong(source)
 				} else if evt.Command == event.CONNECTED {
 					if connectSent {


### PR DESCRIPTION
PING/PONG usually relies on the first parameter, which isn't sent due to ignoring the first argument.